### PR TITLE
Fix Sentinel2 search for a single day interval.

### DIFF
--- a/aws_sat_api/search.py
+++ b/aws_sat_api/search.py
@@ -207,7 +207,7 @@ def sentinel2(utm: Union[str, int], lat: str, grid: str,
     selected_days = []
     for item in days_dirs:
         item_date = datetime(*[int(i) for i in item.split("/")[4:7]], tzinfo=timezone.utc)
-        if start_date <= item_date <= end_date:
+        if start_date.date() <= item_date.date() <= end_date.date():
             selected_days.append(item)
 
     _ls_worker = partial(aws.list_directory, s2_bucket, s3=s3, request_pays=request_pays)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -479,6 +479,25 @@ def test_s2_date_filter(list_directory):
     assert results_date_filter == fixt["results"]
 
 
+@patch('aws_sat_api.aws.list_directory')
+def test_s2_date_filter_single_day(list_directory):
+    start_date = datetime(2017, 1, 12)
+    end_date = datetime(2017, 1, 12)
+
+    path = os.path.join(os.path.dirname(__file__), f'fixtures/s2_search_2017.json')
+    with open(path, 'r') as f:
+        fixt = json.loads(f.read())
+
+    list_directory.side_effect = [
+        fixt["months"],
+        *fixt["days"],
+        *fixt["versions"]]
+
+    results_date_filter = list(search.sentinel2(22, "K", "HV", start_date=start_date, end_date=end_date))
+    assert len(results_date_filter) == 1
+    assert results_date_filter[0] == fixt["results"][0]
+
+
 def test_s2_date_exceptions():
     """Tests if the expected exceptions are properly raised."""
     with pytest.raises(ValueError, match="Start date out of range"):


### PR DESCRIPTION
When searching for data for a single day, the results were empty. That was happening because the difference of a few hours between time zones caused the date comparison to fail.
e.g.
```
start_date = datetime(2017, 5, 15)
end_date = datetime(2017, 5, 15)
results = sentinel2(22, "K", "HV", start_date=start_date, end_date=end_date)
```